### PR TITLE
Add time sync from received signals (fixes #73)

### DIFF
--- a/adapters/android/jni/examples/MainActivity.kt
+++ b/adapters/android/jni/examples/MainActivity.kt
@@ -167,7 +167,8 @@ class MainActivity : AppCompatActivity() {
             text: String,
             type: Int,
             quality: Float,
-            mode: Int
+            mode: Int,
+            driftMs: Int
         ) {
             // Update UI with decoded message
             val decoded = String.format(

--- a/adapters/android/jni/java/JS8CallbackHandler.java
+++ b/adapters/android/jni/java/JS8CallbackHandler.java
@@ -20,8 +20,7 @@ public interface JS8CallbackHandler {
      * @param type Message type identifier
      * @param quality Decode quality metric (0-1)
      * @param mode Submode identifier
-     * @param driftMs Suggested total clock drift (ms) that would center this
-     *                signal's cycle; see JS8Engine.setTimeDriftMs()
+     * @param driftMs Suggested total drift (ms) to center this signal's cycle
      */
     void onDecoded(int utc, int snr, float dt, float freq,
                    String text, int type, float quality, int mode, int driftMs);

--- a/adapters/android/jni/java/JS8CallbackHandler.java
+++ b/adapters/android/jni/java/JS8CallbackHandler.java
@@ -20,9 +20,11 @@ public interface JS8CallbackHandler {
      * @param type Message type identifier
      * @param quality Decode quality metric (0-1)
      * @param mode Submode identifier
+     * @param driftMs Suggested total clock drift (ms) that would center this
+     *                signal's cycle; see JS8Engine.setTimeDriftMs()
      */
     void onDecoded(int utc, int snr, float dt, float freq,
-                   String text, int type, float quality, int mode);
+                   String text, int type, float quality, int mode, int driftMs);
 
     /**
      * Called with FFT spectrum data for waterfall display.

--- a/adapters/android/jni/js8_engine_jni.cpp
+++ b/adapters/android/jni/js8_engine_jni.cpp
@@ -44,6 +44,8 @@ JNIEXPORT jboolean JNICALL Java_com_js8call_core_JS8Engine_nativeIsTransmitting(
 JNIEXPORT jboolean JNICALL Java_com_js8call_core_JS8Engine_nativeIsTransmittingAudio(JNIEnv*, jobject, jlong);
 JNIEXPORT jint JNICALL Java_com_js8call_core_JS8Engine_nativeTxMillisecondsUntilAudio(JNIEnv*, jobject, jlong);
 JNIEXPORT void JNICALL Java_com_js8call_core_JS8Engine_nativeSetTxReady(JNIEnv*, jobject, jlong, jboolean);
+JNIEXPORT void JNICALL Java_com_js8call_core_JS8Engine_nativeSetTimeDriftMs(JNIEnv*, jobject, jlong, jlong);
+JNIEXPORT jlong JNICALL Java_com_js8call_core_JS8Engine_nativeGetTimeDriftMs(JNIEnv*, jobject, jlong);
 }
 
 // Global JavaVM reference for callbacks
@@ -400,12 +402,12 @@ static void event_callback(JS8Engine_Native* native, js8core::events::Variant co
     auto rendered = render_decoded_text(*decoded);
 
     auto emit_decoded = [&](js8core::events::Decoded const& d, std::string const& text_str) {
-      jmethodID method = env->GetMethodID(handler_class, "onDecoded", "(IIFFLjava/lang/String;IFI)V");
+      jmethodID method = env->GetMethodID(handler_class, "onDecoded", "(IIFFLjava/lang/String;IFII)V");
       if (method) {
         jstring text = env->NewStringUTF(text_str.c_str());
         env->CallVoidMethod(native->callback_handler, method,
                            d.utc, d.snr, d.xdt, d.frequency,
-                           text, d.type, d.quality, d.mode);
+                           text, d.type, d.quality, d.mode, d.drift_ms);
         env->DeleteLocalRef(text);
       }
     };
@@ -892,6 +894,16 @@ void js8_engine_set_tx_ready(JS8Engine_Native* engine, bool ready) {
   engine->engine->set_tx_ready(ready);
 }
 
+void js8_engine_set_time_drift_ms(JS8Engine_Native* engine, long long drift_ms) {
+  if (!engine || !engine->engine) return;
+  engine->engine->set_time_drift_ms(drift_ms);
+}
+
+long long js8_engine_get_time_drift_ms(JS8Engine_Native* engine) {
+  if (!engine || !engine->engine) return 0;
+  return engine->engine->time_drift_ms();
+}
+
 int js8_engine_is_running(JS8Engine_Native* engine) {
   if (!engine || !engine->engine) return 0;
   // TODO: Add is_running() method to engine interface
@@ -936,6 +948,10 @@ int js8_register_natives(JavaVM* vm, JNIEnv* env) {
      (void*)Java_com_js8call_core_JS8Engine_nativeTxMillisecondsUntilAudio},
     {"nativeSetTxReady", "(JZ)V",
      (void*)Java_com_js8call_core_JS8Engine_nativeSetTxReady},
+    {"nativeSetTimeDriftMs", "(JJ)V",
+     (void*)Java_com_js8call_core_JS8Engine_nativeSetTimeDriftMs},
+    {"nativeGetTimeDriftMs", "(J)J",
+     (void*)Java_com_js8call_core_JS8Engine_nativeGetTimeDriftMs},
     {"nativeIsRunning", "(J)Z", (void*)Java_com_js8call_core_JS8Engine_nativeIsRunning}
   };
 

--- a/adapters/android/jni/js8_engine_jni.h
+++ b/adapters/android/jni/js8_engine_jni.h
@@ -26,6 +26,8 @@ void js8_engine_set_frequency(JS8Engine_Native* engine, uint64_t frequency_hz);
 void js8_engine_set_submodes(JS8Engine_Native* engine, int submodes);
 void js8_engine_set_output_device(JS8Engine_Native* engine, int device_id);
 void js8_engine_set_tx_boost_enabled(JS8Engine_Native* engine, bool enabled);
+void js8_engine_set_time_drift_ms(JS8Engine_Native* engine, long long drift_ms);
+long long js8_engine_get_time_drift_ms(JS8Engine_Native* engine);
 
 // Transmit control
 int js8_engine_transmit_message(JS8Engine_Native* engine,

--- a/adapters/android/jni/js8_jni_methods.cpp
+++ b/adapters/android/jni/js8_jni_methods.cpp
@@ -237,6 +237,25 @@ Java_com_js8call_core_JS8Engine_nativeSetTxBoostEnabled(
   js8_engine_set_tx_boost_enabled(engine, static_cast<bool>(enabled));
 }
 
+JNIEXPORT void JNICALL
+Java_com_js8call_core_JS8Engine_nativeSetTimeDriftMs(
+    JNIEnv* /* env */,
+    jobject /* thiz */,
+    jlong handle,
+    jlong drift_ms) {
+  JS8Engine_Native* engine = reinterpret_cast<JS8Engine_Native*>(handle);
+  js8_engine_set_time_drift_ms(engine, static_cast<long long>(drift_ms));
+}
+
+JNIEXPORT jlong JNICALL
+Java_com_js8call_core_JS8Engine_nativeGetTimeDriftMs(
+    JNIEnv* /* env */,
+    jobject /* thiz */,
+    jlong handle) {
+  JS8Engine_Native* engine = reinterpret_cast<JS8Engine_Native*>(handle);
+  return static_cast<jlong>(js8_engine_get_time_drift_ms(engine));
+}
+
 JNIEXPORT jboolean JNICALL
 Java_com_js8call_core_JS8Engine_nativeTransmitMessage(
     JNIEnv* env,

--- a/adapters/android/jni/kotlin/JS8AudioHelper.kt
+++ b/adapters/android/jni/kotlin/JS8AudioHelper.kt
@@ -516,10 +516,10 @@ class UIThreadCallbackAdapter(
 
     override fun onDecoded(
         utc: Int, snr: Int, dt: Float, freq: Float,
-        text: String, type: Int, quality: Float, mode: Int
+        text: String, type: Int, quality: Float, mode: Int, driftMs: Int
     ) {
         handler.post {
-            delegate.onDecoded(utc, snr, dt, freq, text, type, quality, mode)
+            delegate.onDecoded(utc, snr, dt, freq, text, type, quality, mode, driftMs)
         }
     }
 

--- a/adapters/android/jni/kotlin/JS8Engine.kt
+++ b/adapters/android/jni/kotlin/JS8Engine.kt
@@ -238,6 +238,19 @@ class JS8Engine private constructor(
     }
 
     /**
+     * Set the clock drift offset (ms) applied to all cycle timing. Positive
+     * means the engine's clock runs ahead of the system clock.
+     */
+    fun setTimeDriftMs(driftMs: Long) {
+        withNativeHandle { nativeSetTimeDriftMs(it, driftMs) }
+    }
+
+    /** Current clock drift offset in milliseconds. */
+    fun timeDriftMs(): Long {
+        return withNativeHandleOr(0L) { nativeGetTimeDriftMs(it) }
+    }
+
+    /**
      * Close and destroy the engine. After calling this, the engine cannot be used.
      */
     override fun close() {
@@ -328,6 +341,8 @@ class JS8Engine private constructor(
     private external fun nativeIsTransmittingAudio(handle: Long): Boolean
     private external fun nativeTxMillisecondsUntilAudio(handle: Long): Int
     private external fun nativeSetTxReady(handle: Long, ready: Boolean)
+    private external fun nativeSetTimeDriftMs(handle: Long, driftMs: Long)
+    private external fun nativeGetTimeDriftMs(handle: Long): Long
 
     /**
      * Callback interface for engine events.
@@ -345,7 +360,8 @@ class JS8Engine private constructor(
             text: String,
             type: Int,
             quality: Float,
-            mode: Int
+            mode: Int,
+            driftMs: Int
         )
 
         /**

--- a/adapters/android/jni/kotlin/JS8Engine.kt
+++ b/adapters/android/jni/kotlin/JS8Engine.kt
@@ -237,10 +237,7 @@ class JS8Engine private constructor(
         withNativeHandle { nativeSetTxReady(it, ready) }
     }
 
-    /**
-     * Set the clock drift offset (ms) applied to all cycle timing. Positive
-     * means the engine's clock runs ahead of the system clock.
-     */
+    /** Positive = engine clock ahead of system clock. */
     fun setTimeDriftMs(driftMs: Long) {
         withNativeHandle { nativeSetTimeDriftMs(it, driftMs) }
     }

--- a/android/app/src/main/java/com/js8call/example/MainActivity.kt
+++ b/android/app/src/main/java/com/js8call/example/MainActivity.kt
@@ -47,7 +47,8 @@ class MainActivity : AppCompatActivity() {
                     val type = intent.getIntExtra(JS8EngineService.EXTRA_TYPE, 0)
                     val quality = intent.getFloatExtra(JS8EngineService.EXTRA_QUALITY, 0f)
                     val mode = intent.getIntExtra(JS8EngineService.EXTRA_MODE, 0)
-                    decodeViewModel.addDecode(utc, snr, dt, freq, text, type, quality, mode)
+                    val driftMs = intent.getIntExtra(JS8EngineService.EXTRA_DRIFT_MS, 0)
+                    decodeViewModel.addDecode(utc, snr, dt, freq, text, type, quality, mode, driftMs)
                     monitorViewModel.updateSnr(snr)
                 }
                 JS8EngineService.ACTION_MESSAGE_RECEIVED -> {
@@ -142,6 +143,10 @@ class MainActivity : AppCompatActivity() {
                         monitorViewModel.updateFrequency(frequencyHz)
                     }
                 }
+                JS8EngineService.ACTION_TIME_DRIFT -> {
+                    val driftMs = intent.getLongExtra(JS8EngineService.EXTRA_TIME_DRIFT_MS, 0L)
+                    monitorViewModel.updateTimeDrift(driftMs)
+                }
             }
         }
     }
@@ -222,6 +227,7 @@ class MainActivity : AppCompatActivity() {
             addAction(JS8EngineService.ACTION_AUDIO_DEVICE)
             addAction(JS8EngineService.ACTION_ERROR)
             addAction(JS8EngineService.ACTION_RADIO_FREQUENCY)
+            addAction(JS8EngineService.ACTION_TIME_DRIFT)
         }
         LocalBroadcastManager.getInstance(this)
             .registerReceiver(monitorReceiver, monitorFilter)

--- a/android/app/src/main/java/com/js8call/example/model/DecodedMessage.kt
+++ b/android/app/src/main/java/com/js8call/example/model/DecodedMessage.kt
@@ -14,8 +14,7 @@ data class DecodedMessage(
     val type: Int,
     val quality: Float,
     val mode: Int,
-    // Engine-suggested total clock drift (ms) that would center this signal's
-    // cycle; used by "sync clock to this signal".
+    // Suggested total drift (ms); used by "sync clock to this signal".
     val driftMs: Int = 0,
     val timestamp: Long = System.currentTimeMillis()
 ) {

--- a/android/app/src/main/java/com/js8call/example/model/DecodedMessage.kt
+++ b/android/app/src/main/java/com/js8call/example/model/DecodedMessage.kt
@@ -14,6 +14,9 @@ data class DecodedMessage(
     val type: Int,
     val quality: Float,
     val mode: Int,
+    // Engine-suggested total clock drift (ms) that would center this signal's
+    // cycle; used by "sync clock to this signal".
+    val driftMs: Int = 0,
     val timestamp: Long = System.currentTimeMillis()
 ) {
     /**

--- a/android/app/src/main/java/com/js8call/example/model/EngineState.kt
+++ b/android/app/src/main/java/com/js8call/example/model/EngineState.kt
@@ -21,6 +21,7 @@ enum class EngineState {
     val frequency: Long = 14078000, // Default to 20m JS8 frequency
     val audioDevice: String = "Unknown",
     val txOffsetHz: Float = 1500f, // Default TX offset
+    val timeDriftMs: Long = 0L,
     val errorMessage: String? = null
 ) {
     val isRunning: Boolean

--- a/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
+++ b/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
@@ -1462,13 +1462,6 @@ class JS8EngineService : Service() {
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
     }
 
-    // --- Time sync -----------------------------------------------------------
-    //
-    // Each decode carries the engine's suggested total drift (ms). In one-shot
-    // mode the first suggestion is applied directly; in continuous auto-sync a
-    // modified moving average smooths suggestions (desktop behavior, capped at
-    // 60 observations) before being applied.
-
     private var timeSyncOncePending = false
     private var driftMmaMs = 0L
     private var driftMmaN = 0
@@ -2200,8 +2193,7 @@ class JS8EngineService : Service() {
             return
         }
 
-        // Work in the drifted timeline so heartbeat slots line up with the
-        // engine's (possibly drift-adjusted) cycle boundaries.
+        // Drifted timeline, so slots match the engine's cycle boundaries.
         val now = System.currentTimeMillis() + (engine?.timeDriftMs() ?: 0L)
         val frameDuration = getFrameDurationMs()
 

--- a/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
+++ b/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
@@ -329,6 +329,18 @@ class JS8EngineService : Service() {
                 val txIntent = Intent(intent)
                 txHandler.post { handleTransmitMessage(txIntent) }
             }
+            ACTION_TIME_SYNC_ONCE -> {
+                Log.i(TAG, "One-shot time sync armed; waiting for next decode")
+                timeSyncOncePending = true
+            }
+            ACTION_SET_TIME_DRIFT -> {
+                val driftMs = intent.getLongExtra(EXTRA_TIME_DRIFT_MS, 0L)
+                Log.i(TAG, "Setting time drift to $driftMs ms")
+                timeSyncOncePending = false
+                driftMmaMs = driftMs
+                driftMmaN = if (driftMs == 0L) 0 else 1
+                applyTimeDrift(driftMs)
+            }
         }
         return START_STICKY
     }
@@ -450,15 +462,16 @@ class JS8EngineService : Service() {
             val callbackHandler = object : JS8Engine.CallbackHandler {
                 override fun onDecoded(
                     utc: Int, snr: Int, dt: Float, freq: Float,
-                    text: String, type: Int, quality: Float, mode: Int
+                    text: String, type: Int, quality: Float, mode: Int, driftMs: Int
                 ) {
                     Log.d(TAG, "Decoded: $text (SNR: $snr dB)")
                     logRxDecode(text, snr, freq, mode)
 
                     // Broadcast on main thread
                     mainHandler.post {
+                        maybeApplyTimeSync(driftMs)
                         updateHeardCallsign(text)
-                        broadcastDecode(utc, snr, dt, freq, text, type, quality, mode)
+                        broadcastDecode(utc, snr, dt, freq, text, type, quality, mode, driftMs)
                         handleRelayFrame(text, snr, mode, freq, type)
                         maybeHandleIncomingMessage(text, snr, freq, type)
                         maybeHandleAutoReply(text, snr, mode)
@@ -532,6 +545,7 @@ class JS8EngineService : Service() {
                 spectrumEventCount = 0
 
                 applyTxBoostSetting()
+                applyTimeDriftSetting()
 
                 if (rigControlMode == "trusdx_serial") {
                     Log.i(TAG, "TruSDX mode active: skipping microphone capture")
@@ -1432,7 +1446,7 @@ class JS8EngineService : Service() {
 
     private fun broadcastDecode(
         utc: Int, snr: Int, dt: Float, freq: Float,
-        text: String, type: Int, quality: Float, mode: Int
+        text: String, type: Int, quality: Float, mode: Int, driftMs: Int
     ) {
         val intent = Intent(ACTION_DECODE).apply {
             putExtra(EXTRA_UTC, utc)
@@ -1443,6 +1457,69 @@ class JS8EngineService : Service() {
             putExtra(EXTRA_TYPE, type)
             putExtra(EXTRA_QUALITY, quality)
             putExtra(EXTRA_MODE, mode)
+            putExtra(EXTRA_DRIFT_MS, driftMs)
+        }
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
+    }
+
+    // --- Time sync -----------------------------------------------------------
+    //
+    // Each decode carries the engine's suggested total drift (ms). In one-shot
+    // mode the first suggestion is applied directly; in continuous auto-sync a
+    // modified moving average smooths suggestions (desktop behavior, capped at
+    // 60 observations) before being applied.
+
+    private var timeSyncOncePending = false
+    private var driftMmaMs = 0L
+    private var driftMmaN = 0
+
+    private fun maybeApplyTimeSync(suggestedDriftMs: Int) {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val autoSync = prefs.getBoolean(PREF_TIME_SYNC_AUTO, false)
+        if (!autoSync && !timeSyncOncePending) return
+
+        if (timeSyncOncePending) {
+            timeSyncOncePending = false
+            driftMmaMs = suggestedDriftMs.toLong()
+            driftMmaN = 1
+            applyTimeDrift(suggestedDriftMs.toLong())
+            return
+        }
+
+        if (driftMmaN == 0) {
+            driftMmaN = 1
+            driftMmaMs = engine?.timeDriftMs() ?: 0L
+        }
+        driftMmaMs = (((driftMmaN - 1) * driftMmaMs) + suggestedDriftMs) / driftMmaN
+        if (driftMmaN < 60) driftMmaN++
+        applyTimeDrift(driftMmaMs)
+    }
+
+    private fun applyTimeDrift(driftMs: Long) {
+        engine?.setTimeDriftMs(driftMs)
+        PreferenceManager.getDefaultSharedPreferences(this)
+            .edit()
+            .putLong(PREF_TIME_DRIFT_MS, driftMs)
+            .apply()
+        Log.i(TAG, "Time drift applied: $driftMs ms")
+        broadcastTimeDrift(driftMs)
+        // TX slots are computed against the drifted clock now; reschedule.
+        scheduleHeartbeat(false)
+    }
+
+    private fun applyTimeDriftSetting() {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(this)
+        val driftMs = prefs.getLong(PREF_TIME_DRIFT_MS, 0L)
+        if (driftMs != 0L) {
+            engine?.setTimeDriftMs(driftMs)
+            Log.i(TAG, "Time drift restored: $driftMs ms")
+        }
+        broadcastTimeDrift(driftMs)
+    }
+
+    private fun broadcastTimeDrift(driftMs: Long) {
+        val intent = Intent(ACTION_TIME_DRIFT).apply {
+            putExtra(EXTRA_TIME_DRIFT_MS, driftMs)
         }
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent)
     }
@@ -2123,9 +2200,11 @@ class JS8EngineService : Service() {
             return
         }
 
-        val now = System.currentTimeMillis()
+        // Work in the drifted timeline so heartbeat slots line up with the
+        // engine's (possibly drift-adjusted) cycle boundaries.
+        val now = System.currentTimeMillis() + (engine?.timeDriftMs() ?: 0L)
         val frameDuration = getFrameDurationMs()
-        
+
         // Base delay
         var delay = if (first) {
             // If first run, schedule for the next available slot (plus a small random wait to avoid instant blast?)
@@ -3741,6 +3820,9 @@ class JS8EngineService : Service() {
         const val ACTION_RADIO_FREQUENCY = "com.js8call.example.ACTION_RADIO_FREQUENCY"
         const val ACTION_MESSAGE_RECEIVED = "com.js8call.example.ACTION_MESSAGE_RECEIVED"
         const val ACTION_QUEUE_TX = "com.js8call.example.ACTION_QUEUE_TX"
+        const val ACTION_TIME_SYNC_ONCE = "com.js8call.example.ACTION_TIME_SYNC_ONCE"
+        const val ACTION_SET_TIME_DRIFT = "com.js8call.example.ACTION_SET_TIME_DRIFT"
+        const val ACTION_TIME_DRIFT = "com.js8call.example.ACTION_TIME_DRIFT"
 
         // Engine states
         const val STATE_STOPPED = "stopped"
@@ -3758,6 +3840,8 @@ class JS8EngineService : Service() {
         const val EXTRA_TYPE = "type"
         const val EXTRA_QUALITY = "quality"
         const val EXTRA_MODE = "mode"
+        const val EXTRA_DRIFT_MS = "drift_ms"
+        const val EXTRA_TIME_DRIFT_MS = "time_drift_ms"
         const val EXTRA_BINS = "bins"
         const val EXTRA_BIN_HZ = "bin_hz"
         const val EXTRA_POWER_DB = "power_db"
@@ -3789,6 +3873,8 @@ class JS8EngineService : Service() {
         const val EXTRA_QUEUE_TX_PRIORITY = "queue_tx_priority"
         const val PREF_TRANSMIT_MODE = "transmit_mode"
         const val PREF_HEARTBEAT_INTERVAL = "heartbeat_interval"
+        const val PREF_TIME_SYNC_AUTO = "time_sync_auto"
+        const val PREF_TIME_DRIFT_MS = "time_drift_ms"
         const val PREF_LOG_MESSAGES = "log_messages_to_file"
         const val RIG_MODE_USB = "USB"
         const val RIG_MODE_PKTUSB = "PKTUSB"

--- a/android/app/src/main/java/com/js8call/example/ui/DecodeFragment.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/DecodeFragment.kt
@@ -106,7 +106,8 @@ class DecodeFragment : Fragment() {
     private fun showDecodeOptions(decode: com.js8call.example.model.DecodedMessage) {
         val options = arrayOf(
             getString(R.string.decodes_copy),
-            getString(R.string.decodes_reply)
+            getString(R.string.decodes_reply),
+            getString(R.string.decodes_sync_time, decode.driftMs)
         )
 
         MaterialAlertDialogBuilder(requireContext())
@@ -115,9 +116,23 @@ class DecodeFragment : Fragment() {
                 when (which) {
                     0 -> copyToClipboard(decode.text)
                     1 -> replyToMessage(decode)
+                    2 -> syncTimeToSignal(decode)
                 }
             }
             .show()
+    }
+
+    private fun syncTimeToSignal(decode: com.js8call.example.model.DecodedMessage) {
+        val intent = android.content.Intent(requireContext(), com.js8call.example.service.JS8EngineService::class.java).apply {
+            action = com.js8call.example.service.JS8EngineService.ACTION_SET_TIME_DRIFT
+            putExtra(com.js8call.example.service.JS8EngineService.EXTRA_TIME_DRIFT_MS, decode.driftMs.toLong())
+        }
+        requireContext().startService(intent)
+        android.widget.Toast.makeText(
+            requireContext(),
+            getString(R.string.decodes_sync_time_applied, decode.driftMs),
+            android.widget.Toast.LENGTH_SHORT
+        ).show()
     }
 
     private fun copyToClipboard(text: String) {

--- a/android/app/src/main/java/com/js8call/example/ui/DecodeViewModel.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/DecodeViewModel.kt
@@ -129,6 +129,7 @@ class DecodeViewModel(application: Application) : AndroidViewModel(application) 
                         type = obj.optInt("type"),
                         quality = obj.optDouble("quality").toFloat(),
                         mode = obj.optInt("mode"),
+                        driftMs = obj.optInt("driftMs"),
                         timestamp = obj.optLong("timestamp", System.currentTimeMillis())
                     )
                 )
@@ -155,9 +156,10 @@ class DecodeViewModel(application: Application) : AndroidViewModel(application) 
         text: String,
         type: Int,
         quality: Float,
-        mode: Int
+        mode: Int,
+        driftMs: Int = 0
     ) {
-        val message = DecodedMessage(utc, snr, dt, freq, text, type, quality, mode)
+        val message = DecodedMessage(utc, snr, dt, freq, text, type, quality, mode, driftMs)
 
         // Clean up stale buffers before processing new message
         cleanupStaleBuffers()
@@ -263,6 +265,7 @@ class DecodeViewModel(application: Application) : AndroidViewModel(application) 
             type = lastFrame.type,
             quality = lastFrame.quality,
             mode = lastFrame.mode,
+            driftMs = lastFrame.driftMs,
             timestamp = lastFrame.timestamp
         )
     }
@@ -398,6 +401,7 @@ class DecodeViewModel(application: Application) : AndroidViewModel(application) 
             obj.put("type", decode.type)
             obj.put("quality", decode.quality)
             obj.put("mode", decode.mode)
+            obj.put("driftMs", decode.driftMs)
             obj.put("timestamp", decode.timestamp)
             arr.put(obj)
         }

--- a/android/app/src/main/java/com/js8call/example/ui/MonitorFragment.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/MonitorFragment.kt
@@ -38,6 +38,9 @@ class MonitorFragment : Fragment() {
     private lateinit var snrValue: TextView
     private lateinit var powerValue: TextView
     private lateinit var txOffsetValue: TextView
+    private lateinit var timeDriftValue: TextView
+    private lateinit var timeSyncButton: Button
+    private lateinit var timeDriftResetButton: Button
     private lateinit var audioDeviceSpinner: Spinner
     private lateinit var frequencySpinner: Spinner
     private lateinit var startStopButton: Button
@@ -74,6 +77,9 @@ class MonitorFragment : Fragment() {
         snrValue = view.findViewById(R.id.snr_value)
         powerValue = view.findViewById(R.id.power_value)
         txOffsetValue = view.findViewById(R.id.tx_offset_value)
+        timeDriftValue = view.findViewById(R.id.time_drift_value)
+        timeSyncButton = view.findViewById(R.id.time_sync_button)
+        timeDriftResetButton = view.findViewById(R.id.time_drift_reset_button)
         monitorVersionText = view.findViewById(R.id.monitor_version)
         audioDeviceSpinner = view.findViewById(R.id.audio_device_spinner)
         frequencySpinner = view.findViewById(R.id.frequency_spinner)
@@ -116,6 +122,23 @@ class MonitorFragment : Fragment() {
             toggleMonitoring()
         }
 
+        // One-shot time sync: apply the drift suggested by the next decode.
+        timeSyncButton.setOnClickListener {
+            val intent = Intent(requireContext(), JS8EngineService::class.java).apply {
+                action = JS8EngineService.ACTION_TIME_SYNC_ONCE
+            }
+            requireContext().startService(intent)
+            Snackbar.make(requireView(), getString(R.string.monitor_time_sync_armed), Snackbar.LENGTH_SHORT).show()
+        }
+
+        timeDriftResetButton.setOnClickListener {
+            val intent = Intent(requireContext(), JS8EngineService::class.java).apply {
+                action = JS8EngineService.ACTION_SET_TIME_DRIFT
+                putExtra(JS8EngineService.EXTRA_TIME_DRIFT_MS, 0L)
+            }
+            requireContext().startService(intent)
+        }
+
     }
 
     override fun onPause() {
@@ -154,6 +177,13 @@ class MonitorFragment : Fragment() {
             // Update TX offset
             txOffsetValue.text = "${status.txOffsetHz.toInt()} Hz"
             waterfallView.txOffsetHz = status.txOffsetHz
+
+            // Update time drift
+            timeDriftValue.text = if (status.timeDriftMs != 0L) {
+                String.format("%+d ms", status.timeDriftMs)
+            } else {
+                "0 ms"
+            }
 
             // Show error if present
             status.errorMessage?.let { error ->

--- a/android/app/src/main/java/com/js8call/example/ui/MonitorFragment.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/MonitorFragment.kt
@@ -122,7 +122,6 @@ class MonitorFragment : Fragment() {
             toggleMonitoring()
         }
 
-        // One-shot time sync: apply the drift suggested by the next decode.
         timeSyncButton.setOnClickListener {
             val intent = Intent(requireContext(), JS8EngineService::class.java).apply {
                 action = JS8EngineService.ACTION_TIME_SYNC_ONCE

--- a/android/app/src/main/java/com/js8call/example/ui/MonitorViewModel.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/MonitorViewModel.kt
@@ -104,6 +104,13 @@ class MonitorViewModel(application: Application) : AndroidViewModel(application)
     }
 
     /**
+     * Update the applied time drift.
+     */
+    fun updateTimeDrift(driftMs: Long) {
+        _status.value = _status.value?.copy(timeDriftMs = driftMs)
+    }
+
+    /**
      * Set the TX offset frequency in Hz.
      */
     fun setTxOffset(offsetHz: Float) {

--- a/android/app/src/main/res/layout/fragment_monitor.xml
+++ b/android/app/src/main/res/layout/fragment_monitor.xml
@@ -50,7 +50,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
                 android:columnCount="2"
-                android:rowCount="5">
+                android:rowCount="6">
 
                 <!-- SNR -->
                 <TextView
@@ -146,6 +146,56 @@
                     android:layout_marginTop="4dp"
                     android:minHeight="32dp"
                     android:spinnerMode="dropdown" />
+
+                <!-- Time Drift -->
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnWeight="1"
+                    android:layout_marginTop="4dp"
+                    android:layout_gravity="center_vertical"
+                    android:text="@string/monitor_time_drift"
+                    android:textSize="12sp"
+                    android:textStyle="bold" />
+
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_columnWeight="1"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/time_drift_value"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="0 ms"
+                        android:textSize="12sp"
+                        tools:text="+1200 ms" />
+
+                    <Button
+                        android:id="@+id/time_sync_button"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:minWidth="0dp"
+                        android:minHeight="32dp"
+                        android:paddingHorizontal="8dp"
+                        android:text="@string/monitor_time_sync"
+                        android:textSize="12sp" />
+
+                    <Button
+                        android:id="@+id/time_drift_reset_button"
+                        style="@style/Widget.Material3.Button.TextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:minWidth="0dp"
+                        android:minHeight="32dp"
+                        android:paddingHorizontal="8dp"
+                        android:text="@string/monitor_time_drift_reset"
+                        android:textSize="12sp" />
+                </LinearLayout>
 
             </GridLayout>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -22,6 +22,10 @@
     <string name="monitor_snr">SNR</string>
     <string name="monitor_power">Power</string>
     <string name="monitor_tx_offset">TX Offset</string>
+    <string name="monitor_time_drift">Time Drift</string>
+    <string name="monitor_time_sync">Sync</string>
+    <string name="monitor_time_drift_reset">Reset</string>
+    <string name="monitor_time_sync_armed">Time sync armed — will apply on next decode</string>
     <string name="monitor_audio_device">Audio Device</string>
     <string name="monitor_radio_frequency">Radio Frequency</string>
 
@@ -31,6 +35,8 @@
     <string name="decodes_clear">Clear</string>
     <string name="decodes_copy">Copy</string>
     <string name="decodes_reply">Reply</string>
+    <string name="decodes_sync_time">Sync clock to this signal (%+d ms)</string>
+    <string name="decodes_sync_time_applied">Time drift set to %+d ms</string>
     <string name="decodes_filter">Filter</string>
     <string name="decode_time">Time</string>
     <string name="decode_snr">SNR</string>
@@ -144,6 +150,9 @@
     <string name="settings_relay_summary">Automatically relay messages using CALL&gt;</string>
 
     <string name="settings_category_heartbeat">Heartbeat</string>
+    <string name="settings_category_timing">Timing</string>
+    <string name="settings_time_sync_auto">Auto time sync</string>
+    <string name="settings_time_sync_auto_summary">Continuously adjust the app\'s clock drift from received signals. Useful off-grid where the device clock cannot sync.</string>
     <string name="settings_heartbeat_interval">Heartbeat Interval</string>
     <string name="settings_heartbeat_interval_summary">Time between automatic heartbeats</string>
 

--- a/android/app/src/main/res/xml/preferences.xml
+++ b/android/app/src/main/res/xml/preferences.xml
@@ -262,4 +262,18 @@
 
     </PreferenceCategory>
 
+    <!-- Timing Category -->
+    <PreferenceCategory
+        app:title="@string/settings_category_timing"
+        app:iconSpaceReserved="false">
+
+        <SwitchPreferenceCompat
+            app:key="time_sync_auto"
+            app:title="@string/settings_time_sync_auto"
+            app:summary="@string/settings_time_sync_auto_summary"
+            app:defaultValue="false"
+            app:iconSpaceReserved="false" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/android/js8core-lib/src/androidTest/java/com/js8call/core/JS8EngineAudioSubmissionTest.kt
+++ b/android/js8core-lib/src/androidTest/java/com/js8call/core/JS8EngineAudioSubmissionTest.kt
@@ -37,7 +37,8 @@ class JS8EngineAudioSubmissionTest {
             text: String,
             type: Int,
             quality: Float,
-            mode: Int
+            mode: Int,
+            driftMs: Int
         ) = Unit
 
         override fun onSpectrum(

--- a/android/js8core-lib/src/androidTest/java/com/js8call/core/JS8EngineLifecycleTest.kt
+++ b/android/js8core-lib/src/androidTest/java/com/js8call/core/JS8EngineLifecycleTest.kt
@@ -99,7 +99,8 @@ class JS8EngineLifecycleTest {
                     text: String,
                     type: Int,
                     quality: Float,
-                    mode: Int
+                    mode: Int,
+                    driftMs: Int
                 ) = Unit
 
                 override fun onSpectrum(
@@ -157,7 +158,8 @@ class JS8EngineLifecycleTest {
             text: String,
             type: Int,
             quality: Float,
-            mode: Int
+            mode: Int,
+            driftMs: Int
         ) = Unit
 
         override fun onSpectrum(

--- a/android/js8core-lib/src/androidTest/java/com/js8call/core/JS8EngineTxTimingTest.kt
+++ b/android/js8core-lib/src/androidTest/java/com/js8call/core/JS8EngineTxTimingTest.kt
@@ -69,7 +69,8 @@ class JS8EngineTxTimingTest {
             text: String,
             type: Int,
             quality: Float,
-            mode: Int
+            mode: Int,
+            driftMs: Int
         ) = Unit
 
         override fun onSpectrum(

--- a/core/include/js8core/decoder_state.hpp
+++ b/core/include/js8core/decoder_state.hpp
@@ -37,6 +37,8 @@ struct DecodeParams {
 struct DecodeState {
   std::vector<std::int16_t> samples;  // size kJs8NtMax * kJs8RxSampleRate
   DecodeParams params;
+  // Drift the ring alignment used at snapshot time; estimates must use this, not current drift.
+  std::int64_t drift_ms_at_capture = 0;
 };
 
 struct SpectrumState {

--- a/core/include/js8core/engine.hpp
+++ b/core/include/js8core/engine.hpp
@@ -51,8 +51,7 @@ struct Decoded {
   int type = 0;
   float quality = 0.0f;
   int mode = 0;
-  // Suggested total clock drift (ms) that would center this signal's cycle,
-  // computed from the decode window position and xdt; see set_time_drift_ms().
+  // Suggested total drift (ms) to center this signal's cycle.
   int drift_ms = 0;
 };
 
@@ -134,9 +133,7 @@ public:
   virtual void set_tx_ready(bool ready) = 0;
   virtual void set_tx_boost_enabled(bool enabled) = 0;
 
-  // Clock drift offset applied to all cycle timing (RX decode windows, TX start,
-  // decode UTC stamps). Positive means the engine's clock runs ahead of the
-  // system clock. Takes effect at the next captured audio buffer.
+  // Positive = engine clock ahead of system clock; takes effect at the next captured buffer.
   virtual void set_time_drift_ms(std::int64_t drift_ms) = 0;
   virtual std::int64_t time_drift_ms() const = 0;
 };

--- a/core/include/js8core/engine.hpp
+++ b/core/include/js8core/engine.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -50,6 +51,9 @@ struct Decoded {
   int type = 0;
   float quality = 0.0f;
   int mode = 0;
+  // Suggested total clock drift (ms) that would center this signal's cycle,
+  // computed from the decode window position and xdt; see set_time_drift_ms().
+  int drift_ms = 0;
 };
 
 struct DecodeFinished {
@@ -129,6 +133,12 @@ public:
   virtual int tx_milliseconds_until_audio() const = 0;
   virtual void set_tx_ready(bool ready) = 0;
   virtual void set_tx_boost_enabled(bool enabled) = 0;
+
+  // Clock drift offset applied to all cycle timing (RX decode windows, TX start,
+  // decode UTC stamps). Positive means the engine's clock runs ahead of the
+  // system clock. Takes effect at the next captured audio buffer.
+  virtual void set_time_drift_ms(std::int64_t drift_ms) = 0;
+  virtual std::int64_t time_drift_ms() const = 0;
 };
 
 std::unique_ptr<Js8Engine> make_engine(EngineConfig const& config,

--- a/core/include/js8core/tx/modulator.hpp
+++ b/core/include/js8core/tx/modulator.hpp
@@ -21,6 +21,9 @@ public:
              bool tuning);
 
   void stop();
+  // Offset added to the wall clock when aligning TX start to the cycle
+  // boundary; mirrors the engine's time drift.
+  void set_clock_offset_ms(std::int64_t offset_ms) { clock_offset_ms_.store(offset_ms); }
   bool is_idle() const { return state_.load() == State::Idle; }
   bool is_active() const { return state_.load() == State::Active; }
   int milliseconds_until_active() const;
@@ -40,6 +43,7 @@ private:
   double dphi_ = 0.0;
   double amp_ = 1.0;
   std::atomic<std::int64_t> silent_frames_{0};
+  std::atomic<std::int64_t> clock_offset_ms_{0};
   std::uint64_t ic_ = 0;
   std::uint64_t isym0_ = 0;
 };

--- a/core/include/js8core/tx/modulator.hpp
+++ b/core/include/js8core/tx/modulator.hpp
@@ -21,8 +21,6 @@ public:
              bool tuning);
 
   void stop();
-  // Offset added to the wall clock when aligning TX start to the cycle
-  // boundary; mirrors the engine's time drift.
   void set_clock_offset_ms(std::int64_t offset_ms) { clock_offset_ms_.store(offset_ms); }
   bool is_idle() const { return state_.load() == State::Idle; }
   bool is_active() const { return state_.load() == State::Active; }

--- a/core/src/engine/engine.cpp
+++ b/core/src/engine/engine.cpp
@@ -351,8 +351,6 @@ public:
   void set_time_drift_ms(std::int64_t drift_ms) override {
     if (time_drift_ms_.exchange(drift_ms) == drift_ms) return;
     tx_modulator_.set_clock_offset_ms(drift_ms);
-    // The ring buffer phase is owned by the audio thread; realign there just
-    // before the next buffer is written rather than racing it here.
     drift_realign_pending_.store(true);
     if (callbacks_.on_log) {
       char log_msg[128];
@@ -391,18 +389,15 @@ public:
       bool tuning = false;
     };
 
-    // Wall clock shifted by the current time drift; all cycle timing derives
-    // from this so RX windows, TX starts, and UTC stamps stay coherent.
     std::chrono::system_clock::time_point drifted_now() const {
       return std::chrono::system_clock::now() +
              std::chrono::milliseconds(time_drift_ms_.load());
     }
 
-    // (Re)aligns the ring buffer write position to the drifted clock. Runs on
-    // the constructor and, after a drift change, on the audio thread before
-    // the next buffer is written (see submit_capture).
+    // Runs at construction and, after a drift change, on the audio thread (see submit_capture).
     void align_ring_to_clock() {
       auto const sample_rate = config_.sample_rate_hz ? config_.sample_rate_hz : kJs8RxSampleRate;
+      ring_drift_ms_ = time_drift_ms_.load();
       auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
           drifted_now().time_since_epoch());
       // JS8 RX buffer spans 60 seconds; use milliseconds into the current minute.
@@ -721,6 +716,7 @@ public:
       DecodeState snapshot;
       snapshot.params = decode_state_.params;
       snapshot.samples = decode_state_.samples;
+      snapshot.drift_ms_at_capture = ring_drift_ms_;
       enqueue_decode(std::move(snapshot));
     }
 
@@ -998,6 +994,8 @@ public:
     int k0_{0};  // Previous sample position for isDecodeReady logic
     std::atomic<std::int64_t> time_drift_ms_{0};
     std::atomic<bool> drift_realign_pending_{false};
+    // Written only on the audio thread; may lag time_drift_ms_ by one capture buffer.
+    std::int64_t ring_drift_ms_{0};
     bool running_{false};
     std::mutex tx_mutex_;
     std::deque<TxFrame> tx_queue_;
@@ -1037,14 +1035,10 @@ public:
     std::deque<SpectrumTask> spectrum_queue_;
     bool spectrum_stop_{false};
 
-    // Port of the desktop auto-sync math (mainwindow.cpp, events::Decoded):
-    // place the decoded signal within the drifted minute using its decode
-    // window position and xdt, measure the distance to the nearest cycle
-    // boundary, and fold that into the current drift. The result is the total
-    // drift (ms) that would center this signal in its cycle.
+    // Desktop auto-sync math (mainwindow.cpp, events::Decoded handler).
     int compute_drift_estimate(DecodeState const& task, events::Decoded const& d) const {
       auto sm = submode_from_varicode(d.mode);
-      if (!sm) return static_cast<int>(time_drift_ms_.load());
+      if (!sm) return static_cast<int>(task.drift_ms_at_capture);
 
       int kpos = 0;
       switch (sm->id) {
@@ -1070,7 +1064,7 @@ public:
       if (drift + period_ms < std::abs(drift)) drift += period_ms;
       else if (std::abs(drift - period_ms) < drift) drift -= period_ms;
 
-      auto total = time_drift_ms_.load() + drift;
+      auto total = task.drift_ms_at_capture + drift;
       total %= period_ms;
       return static_cast<int>(total);
     }

--- a/core/src/engine/engine.cpp
+++ b/core/src/engine/engine.cpp
@@ -68,25 +68,7 @@ public:
 
     // Align the ring buffer position to wall clock so decode windows line up with
     // the desktop timing (cycles relative to UTC within the current minute).
-    {
-      auto const sample_rate = config_.sample_rate_hz ? config_.sample_rate_hz : kJs8RxSampleRate;
-      using clock = std::chrono::system_clock;
-      auto now = clock::now();
-      auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
-      // JS8 RX buffer spans 60 seconds; use milliseconds into the current minute.
-      auto ms_in_minute = ms_since_epoch.count() % (kJs8NtMax * 1000);
-      int aligned = static_cast<int>((ms_in_minute * sample_rate) / 1000);
-      decode_state_.params.kin = aligned;
-      total_samples_ = aligned;
-      k0_ = aligned;
-      if (callbacks_.on_log) {
-        char log_msg[256];
-        snprintf(log_msg, sizeof(log_msg),
-                 "Ring buffer aligned to UTC minute: ms_in_minute=%lld, offset_samples=%d, sample_rate=%d",
-                 static_cast<long long>(ms_in_minute), aligned, sample_rate);
-        callbacks_.on_log(LogLevel::Info, log_msg);
-      }
-    }
+    align_ring_to_clock();
 
     if (config_.submodes == 0) {
       int mask = 0;
@@ -157,6 +139,11 @@ public:
     if (config_.sample_rate_hz && buffer.format.sample_rate != config_.sample_rate_hz) {
       if (callbacks_.on_error) callbacks_.on_error("Unexpected sample rate");
       return false;
+    }
+
+    // Apply a pending drift change here, on the thread that owns the ring state.
+    if (drift_realign_pending_.exchange(false)) {
+      align_ring_to_clock();
     }
 
     auto bytes_per_sample = static_cast<std::size_t>(sizeof(std::int16_t) * buffer.format.channels);
@@ -361,6 +348,24 @@ public:
     config_.tx_output_gain_boost_enabled = enabled;
   }
 
+  void set_time_drift_ms(std::int64_t drift_ms) override {
+    if (time_drift_ms_.exchange(drift_ms) == drift_ms) return;
+    tx_modulator_.set_clock_offset_ms(drift_ms);
+    // The ring buffer phase is owned by the audio thread; realign there just
+    // before the next buffer is written rather than racing it here.
+    drift_realign_pending_.store(true);
+    if (callbacks_.on_log) {
+      char log_msg[128];
+      snprintf(log_msg, sizeof(log_msg),
+               "Time drift set to %lld ms", static_cast<long long>(drift_ms));
+      callbacks_.on_log(LogLevel::Info, log_msg);
+    }
+  }
+
+  std::int64_t time_drift_ms() const override {
+    return time_drift_ms_.load();
+  }
+
  private:
     struct SubmodeSchedule {
       protocol::SubmodeId id;
@@ -386,10 +391,45 @@ public:
       bool tuning = false;
     };
 
+    // Wall clock shifted by the current time drift; all cycle timing derives
+    // from this so RX windows, TX starts, and UTC stamps stay coherent.
+    std::chrono::system_clock::time_point drifted_now() const {
+      return std::chrono::system_clock::now() +
+             std::chrono::milliseconds(time_drift_ms_.load());
+    }
+
+    // (Re)aligns the ring buffer write position to the drifted clock. Runs on
+    // the constructor and, after a drift change, on the audio thread before
+    // the next buffer is written (see submit_capture).
+    void align_ring_to_clock() {
+      auto const sample_rate = config_.sample_rate_hz ? config_.sample_rate_hz : kJs8RxSampleRate;
+      auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+          drifted_now().time_since_epoch());
+      // JS8 RX buffer spans 60 seconds; use milliseconds into the current minute.
+      auto ms_in_minute = ms_since_epoch.count() % (kJs8NtMax * 1000);
+      int aligned = static_cast<int>((ms_in_minute * sample_rate) / 1000);
+      decode_state_.params.kin = aligned;
+      total_samples_ = aligned;
+      k0_ = aligned;
+      // Force every schedule to re-snap its decode window to the new phase.
+      for (auto& sch : schedules_) {
+        sch.current_decode_start = -1;
+        sch.next_decode_start = -1;
+      }
+      if (callbacks_.on_log) {
+        char log_msg[256];
+        snprintf(log_msg, sizeof(log_msg),
+                 "Ring buffer aligned to UTC minute: ms_in_minute=%lld, offset_samples=%d, sample_rate=%d, drift_ms=%lld",
+                 static_cast<long long>(ms_in_minute), aligned, sample_rate,
+                 static_cast<long long>(time_drift_ms_.load()));
+        callbacks_.on_log(LogLevel::Info, log_msg);
+      }
+    }
+
     void init_schedules() {
       // Get current UTC time to synchronize decode windows
       using clock = std::chrono::system_clock;
-      auto now = clock::now();
+      auto now = drifted_now();
       auto t = clock::to_time_t(now);
       std::tm utc_tm{};
 #if defined(_WIN32)
@@ -468,7 +508,7 @@ public:
 
     void populate_decode_metadata() {
       using clock = std::chrono::system_clock;
-      auto now = clock::now();
+      auto now = drifted_now();
       auto t = clock::to_time_t(now);
       std::tm utc_tm{};
 #if defined(_WIN32)
@@ -574,9 +614,8 @@ public:
       static int drift_log_counter = 0;
       if (++drift_log_counter % 200 == 0 && callbacks_.on_log) {
         auto const sample_rate = config_.sample_rate_hz ? config_.sample_rate_hz : kJs8RxSampleRate;
-        using clock = std::chrono::system_clock;
-        auto now = clock::now();
-        auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch());
+        auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+            drifted_now().time_since_epoch());
         int ms_in_minute = static_cast<int>(ms_since_epoch.count() % (kJs8NtMax * 1000));
         int k_ms = static_cast<int>((static_cast<long long>(k) * 1000) / sample_rate);
         int delta_ms = ms_in_minute - k_ms;
@@ -957,6 +996,8 @@ public:
     std::vector<SubmodeSchedule> schedules_;
     int total_samples_{0};
     int k0_{0};  // Previous sample position for isDecodeReady logic
+    std::atomic<std::int64_t> time_drift_ms_{0};
+    std::atomic<bool> drift_realign_pending_{false};
     bool running_{false};
     std::mutex tx_mutex_;
     std::deque<TxFrame> tx_queue_;
@@ -995,6 +1036,44 @@ public:
     };
     std::deque<SpectrumTask> spectrum_queue_;
     bool spectrum_stop_{false};
+
+    // Port of the desktop auto-sync math (mainwindow.cpp, events::Decoded):
+    // place the decoded signal within the drifted minute using its decode
+    // window position and xdt, measure the distance to the nearest cycle
+    // boundary, and fold that into the current drift. The result is the total
+    // drift (ms) that would center this signal in its cycle.
+    int compute_drift_estimate(DecodeState const& task, events::Decoded const& d) const {
+      auto sm = submode_from_varicode(d.mode);
+      if (!sm) return static_cast<int>(time_drift_ms_.load());
+
+      int kpos = 0;
+      switch (sm->id) {
+        case protocol::SubmodeId::A: kpos = task.params.kposA; break;
+        case protocol::SubmodeId::B: kpos = task.params.kposB; break;
+        case protocol::SubmodeId::C: kpos = task.params.kposC; break;
+        case protocol::SubmodeId::E: kpos = task.params.kposE; break;
+        case protocol::SubmodeId::I: kpos = task.params.kposI; break;
+      }
+
+      auto const sample_rate = config_.sample_rate_hz ? config_.sample_rate_hz : kJs8RxSampleRate;
+      int const period_ms = sm->tx_seconds * 1000;
+
+      float signal_time = static_cast<float>(kpos) / static_cast<float>(sample_rate);
+      signal_time -= static_cast<float>(sm->start_delay_ms) / 1000.0f;
+      signal_time += d.xdt;
+      if (signal_time < 0.0f) signal_time += 60.0f;
+      else if (signal_time > 60.0f) signal_time -= 60.0f;
+
+      int const signal_ms = static_cast<int>(1000.0f * signal_time);
+      int drift = (signal_ms / period_ms) * period_ms - signal_ms;
+      // Take the shorter way around the cycle (-14s becomes +1s, etc).
+      if (drift + period_ms < std::abs(drift)) drift += period_ms;
+      else if (std::abs(drift - period_ms) < drift) drift -= period_ms;
+
+      auto total = time_drift_ms_.load() + drift;
+      total %= period_ms;
+      return static_cast<int>(total);
+    }
 
     void emit_event(events::Variant const& ev) {
       if (!callbacks_.on_event) return;
@@ -1080,7 +1159,13 @@ public:
           callbacks_.on_log(LogLevel::Info, log_msg);
         }
 
-        std::size_t decode_count = legacy_decode(task, [this](events::Variant const& ev) {
+        std::size_t decode_count = legacy_decode(task, [this, &task](events::Variant const& ev) {
+          if (auto const* d = std::get_if<events::Decoded>(&ev)) {
+            auto out = *d;
+            out.drift_ms = compute_drift_estimate(task, out);
+            emit_event(events::Variant{std::move(out)});
+            return;
+          }
           emit_event(ev);
         });
 

--- a/core/src/tx/modulator.cpp
+++ b/core/src/tx/modulator.cpp
@@ -39,8 +39,9 @@ void Modulator::start(std::array<int, protocol::kJs8NumSymbols> const& tones,
 
   if (!tuning_) {
     auto now = std::chrono::system_clock::now();
-    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
-    auto period_offset = static_cast<std::int64_t>(now_ms % period_ms);
+    auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count() +
+                  clock_offset_ms_.load();
+    auto period_offset = static_cast<std::int64_t>(((now_ms % period_ms) + period_ms) % period_ms);
     auto tx_delay_ms = static_cast<std::int64_t>(tx_delay_s * 1000.0);
     auto start_time_ms = static_cast<std::int64_t>(start_delay_ms) + tx_delay_ms;
     if (start_time_ms < 0) start_time_ms = 0;


### PR DESCRIPTION
Implements #73: sync the app's cycle timing from received signals, for off-grid use where the device clock has no NTP/cell reference.

**How it works**

The core engine gains a clock-drift offset (`set_time_drift_ms`) applied everywhere cycle timing derives from the wall clock: the RX ring-buffer phase (realigned race-free on the audio thread at the next captured buffer), decode-window scheduling, TX start alignment in the modulator, and decode UTC stamps. Every decode now carries an engine-computed *suggested total drift*, calculated with the same algorithm desktop JS8Call uses for auto time-drift (decode window position + signal `dt`, folded to the nearest cycle boundary).

**UI**

- Monitor screen: a "Time Drift" row shows the applied offset, with **Sync** (one-shot: applies the next decode's suggestion) and **Reset** buttons.
- Decodes list: tapping a message offers "Sync clock to this signal (+N ms)" with the exact correction shown up front.
- Settings → Timing: an "Auto time sync" switch enables continuous adjustment using the desktop's modified-moving-average smoothing (capped at 60 observations).
- Drift persists across restarts and is restored when the engine starts. Heartbeat TX scheduling is computed on the drifted timeline.

<img width="1920" height="1200" alt="Screenshot_20260818-214702" src="https://github.com/user-attachments/assets/f02e2c20-a65a-4afd-a744-076484927c91" />
<img width="1920" height="1200" alt="Screenshot_20260818-214728" src="https://github.com/user-attachments/assets/63420ef2-43d0-4047-930a-dcf1b25aef5d" />


**Tested**

On-air on a Fire HD 10 (Fire OS 7): with signals decoding, per-signal sync applied a −120 ms correction; engine telemetry confirmed the ring realigned (steady-state clock delta shifted accordingly) and decode windows re-snapped on the next buffer; the value persisted and is restored on restart. Unit tests pass; the JNI decode callback signature change is covered by the updated androidTest fakes.

**Known limitation (matches desktop)**

Sync-from-signals can only correct what the decoder can still see (roughly ±2 s). A clock that is off by more needs a rough manual set first — off-grid, that means setting the device clock to within a couple of seconds by hand or GPS, then letting sync pull it tight. That is the workflow described in #73.
