### PR TITLE
Fixed the Monitor tab showing freq set every time

### DIFF
--- a/android/app/src/main/java/com/js8call/example/ui/MonitorFragment.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/MonitorFragment.kt
@@ -54,7 +54,9 @@ class MonitorFragment : Fragment() {
     private var lastSelectedAudioDeviceId = -1
 
     // Frequency management
-    private var isUpdatingFrequencySpinner = false
+    // Spinner position last applied programmatically; onItemSelected skips it
+    // because setSelection() fires the listener asynchronously.
+    private var appliedFrequencyIndex = -1
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -474,9 +476,11 @@ class MonitorFragment : Fragment() {
             if (currentIndex == closestIndex) {
                 return
             }
-            isUpdatingFrequencySpinner = true
+            appliedFrequencyIndex = closestIndex
             frequencySpinner.setSelection(closestIndex)
-            isUpdatingFrequencySpinner = false
+
+            val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(requireContext())
+            prefs.edit().putString("last_frequency", frequencyValues[closestIndex]).apply()
 
             android.util.Log.i("MonitorFragment", "Set frequency to ${frequencyEntries[closestIndex]} based on radio frequency $frequencyHz Hz")
             Snackbar.make(requireView(), "Radio tuned to ${frequencyEntries[closestIndex]}", Snackbar.LENGTH_SHORT).show()
@@ -522,15 +526,15 @@ class MonitorFragment : Fragment() {
             ?: 0
 
         // Set initial selection
-        isUpdatingFrequencySpinner = true
-        frequencySpinner.setSelection(savedIndex)
-        isUpdatingFrequencySpinner = false
+        appliedFrequencyIndex = savedIndex
+        frequencySpinner.setSelection(savedIndex, false)
 
         // Set up selection listener
         frequencySpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                if (isUpdatingFrequencySpinner) return
+                if (position == appliedFrequencyIndex) return
                 if (position < 0 || position >= frequencyValues.size) return
+                appliedFrequencyIndex = position
 
                 val frequencyHz = frequencyValues[position].toLongOrNull() ?: return
                 android.util.Log.d("MonitorFragment", "Frequency selected: ${frequencyEntries[position]} ($frequencyHz Hz)")


### PR DESCRIPTION
## What
1. Fixes the Monitor tab sending a set-frequency command to the rig and showing a "Setting frequency to..." snackbar every time its view is recreated
2. Stops radio-reported frequency updates from echoing a set-frequency command back to the radio. The app still follows the radio's VFO and now also persists the frequency it reports

## Why
Spinner.setSelection() fires the selection listener asynchronously, after the guard flag was already cleared, so the initial programmatic selection looked like a user action. The listener now tracks the last programmatically applied position and skips it.

## Test
1. Enable rig control with a connected radio
2. Switch between tabs a few times: no snackbar, no CAT traffic on open
3. Change the frequency from the spinner: command is sent and snackbar shows as before
4. Tune the radio's VFO to another preset: the app follows and shows "Radio tuned to..."

Verified on a Fire HD 10 with an X6200 over USB CAT.
