### PR TITLE
Add callsign autosuggest to the directed field and fix reply prefill

### DIFF
--- a/android/app/src/main/java/com/js8call/example/data/MessageDao.kt
+++ b/android/app/src/main/java/com/js8call/example/data/MessageDao.kt
@@ -107,6 +107,9 @@ interface MessageDao {
     @Query("SELECT COUNT(*) FROM messages WHERE conversationId = :conversationId AND isRead = 0 AND direction = 0")
     suspend fun getUnreadCountForConversation(conversationId: String): Int
 
+    @Query("SELECT conversationId FROM messages GROUP BY conversationId ORDER BY MAX(timestamp) DESC")
+    fun getConversationCallsigns(): LiveData<List<String>>
+
     // ========== Search ==========
 
     @Query("SELECT * FROM messages WHERE text LIKE '%' || :query || '%' ORDER BY timestamp DESC")

--- a/android/app/src/main/java/com/js8call/example/data/MessageRepository.kt
+++ b/android/app/src/main/java/com/js8call/example/data/MessageRepository.kt
@@ -25,6 +25,10 @@ class MessageRepository(context: Context) {
         }
     }
 
+    fun getConversationCallsigns(): LiveData<List<String>> {
+        return messageDao.getConversationCallsigns()
+    }
+
     // ========== Messages ==========
 
     fun getMessagesForConversation(callsign: String): LiveData<List<MessageEntity>> {

--- a/android/app/src/main/java/com/js8call/example/ui/DecodeViewModel.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/DecodeViewModel.kt
@@ -414,6 +414,19 @@ class DecodeViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     /**
+     * Sender callsigns from the in-memory decode list, newest first.
+     */
+    fun heardCallsigns(): List<String> {
+        return allDecodes.mapNotNull { senderCallsign(it.text) }.distinct()
+    }
+
+    private fun senderCallsign(text: String): String? {
+        val firstToken = text.trim().split(Regex("\\s+"), limit = 2).firstOrNull() ?: return null
+        val callsign = firstToken.trimEnd(':').uppercase()
+        return callsign.takeIf { isCallsignLike(it) }
+    }
+
+    /**
      * Set filter text.
      */
     fun setFilter(text: String) {

--- a/android/app/src/main/java/com/js8call/example/ui/TransmitFragment.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/TransmitFragment.kt
@@ -99,7 +99,6 @@ class TransmitFragment : Fragment() {
         queueRecyclerView.adapter = queueAdapter
 
         // Set up listeners
-        setupListeners()
         setupModeSelector()
         setupSpeedSelector()
 
@@ -108,6 +107,14 @@ class TransmitFragment : Fragment() {
 
         // Register broadcast receiver
         registerBroadcastReceiver()
+    }
+
+    override fun onViewStateRestored(savedInstanceState: Bundle?) {
+        super.onViewStateRestored(savedInstanceState)
+        // Text watchers must attach after view state restoration. Restoring the
+        // saved (stale) field text fires the watchers, which would push it into
+        // the ViewModel and wipe a directed callsign set from another screen.
+        setupListeners()
     }
 
     override fun onDestroyView() {

--- a/android/app/src/main/java/com/js8call/example/ui/TransmitFragment.kt
+++ b/android/app/src/main/java/com/js8call/example/ui/TransmitFragment.kt
@@ -24,8 +24,10 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
+import com.google.android.material.textfield.MaterialAutoCompleteTextView
 import com.google.android.material.textfield.TextInputEditText
 import com.js8call.example.R
+import com.js8call.example.data.MessageRepository
 import com.js8call.example.model.TransmitState
 import com.js8call.example.service.JS8EngineService
 
@@ -35,9 +37,10 @@ import com.js8call.example.service.JS8EngineService
 class TransmitFragment : Fragment() {
 
     private lateinit var viewModel: TransmitViewModel
+    private lateinit var decodeViewModel: DecodeViewModel
 
     private lateinit var messageEditText: TextInputEditText
-    private lateinit var directedEditText: TextInputEditText
+    private lateinit var directedEditText: MaterialAutoCompleteTextView
     private lateinit var sendButton: Button
     private lateinit var queueRecyclerView: RecyclerView
     private lateinit var queueEmptyText: TextView
@@ -51,6 +54,8 @@ class TransmitFragment : Fragment() {
     private lateinit var queueAdapter: TransmitQueueAdapter
     private var currentTxOffset: Float = 1500f
     private var isApplyingDirected: Boolean = false
+    private var conversationCallsigns: List<String> = emptyList()
+    private var heardCallsigns: List<String> = emptyList()
 
     private val preferenceListener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
@@ -81,8 +86,9 @@ class TransmitFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Initialize ViewModel
+        // Initialize ViewModels
         viewModel = ViewModelProvider(requireActivity())[TransmitViewModel::class.java]
+        decodeViewModel = ViewModelProvider(requireActivity())[DecodeViewModel::class.java]
 
         // Find views
         messageEditText = view.findViewById(R.id.message_edit_text)
@@ -135,7 +141,7 @@ class TransmitFragment : Fragment() {
         val current = directedEditText.text?.toString().orEmpty()
         if (directed.isNotBlank() && directed != current) {
             isApplyingDirected = true
-            directedEditText.setText(directed)
+            directedEditText.setText(directed, false)
             directedEditText.setSelection(directed.length)
             isApplyingDirected = false
         }
@@ -275,10 +281,22 @@ class TransmitFragment : Fragment() {
             val current = directedEditText.text?.toString().orEmpty()
             if (callsign.isNotBlank() && callsign != current) {
                 isApplyingDirected = true
-                directedEditText.setText(callsign)
+                directedEditText.setText(callsign, false)
                 directedEditText.setSelection(callsign.length)
                 isApplyingDirected = false
             }
+        }
+
+        // Callsign suggestions: conversation history plus stations heard this session
+        MessageRepository.getInstance(requireContext()).getConversationCallsigns()
+            .observe(viewLifecycleOwner) { callsigns ->
+                conversationCallsigns = callsigns
+                updateCallsignSuggestions()
+            }
+
+        decodeViewModel.decodes.observe(viewLifecycleOwner) {
+            heardCallsigns = decodeViewModel.heardCallsigns()
+            updateCallsignSuggestions()
         }
 
         viewModel.txOffsetHz.observe(viewLifecycleOwner) { offset ->
@@ -304,6 +322,13 @@ class TransmitFragment : Fragment() {
                 queueEmptyText.visibility = View.GONE
             }
         }
+    }
+
+    private fun updateCallsignSuggestions() {
+        val merged = (conversationCallsigns + heardCallsigns).distinct()
+        directedEditText.setAdapter(
+            ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, merged)
+        )
     }
 
     private fun updateSendButtonState() {

--- a/android/app/src/main/res/layout/fragment_transmit.xml
+++ b/android/app/src/main/res/layout/fragment_transmit.xml
@@ -40,7 +40,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/message_input_layout"
-        app:prefixText="@string/tx_directed"
         app:startIconDrawable="@android:drawable/ic_menu_send">
 
         <com.google.android.material.textfield.MaterialAutoCompleteTextView

--- a/android/app/src/main/res/layout/fragment_transmit.xml
+++ b/android/app/src/main/res/layout/fragment_transmit.xml
@@ -43,10 +43,11 @@
         app:prefixText="@string/tx_directed"
         app:startIconDrawable="@android:drawable/ic_menu_send">
 
-        <com.google.android.material.textfield.TextInputEditText
+        <com.google.android.material.textfield.MaterialAutoCompleteTextView
             android:id="@+id/directed_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:completionThreshold="1"
             android:inputType="textCapCharacters"
             android:maxLength="12"
             android:singleLine="true" />

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -48,7 +48,6 @@
     <string name="tx_compose_hint">Type message here…</string>
     <string name="tx_send">Send</string>
     <string name="tx_cq">CQ</string>
-    <string name="tx_directed">To:</string>
     <string name="tx_directed_hint">Directed Callsign</string>
     <string name="tx_snr_report">SNR</string>
     <string name="tx_queue">Queue</string>


### PR DESCRIPTION
## What
1. Fixes reply on a decode leaving the directed callsign field empty
    - Android restores the saved field text after the text watchers attach, so the restore erased the callsign from the ViewModel before its observer ran. The watchers now attach in `onViewStateRestored`.
2. Adds autosuggest to the directed callsign field
    - Merges conversation callsigns from the message database (most recent first) with stations heard in the current decode list.
3. Removes the "To:" prefix from the field
    - It rendered at the top of the focused field, and the "Directed Callsign" label already names it.

<img width="1920" height="1200" alt="Screenshot_20260819-214142" src="https://github.com/user-attachments/assets/da65c181-c79c-4f88-98f1-a42718f27e77" />


## Why
Reply looked broken because the callsign never showed up, and typing callsigns by hand on a tablet keyboard is error prone.

## Test
1. Tap a decode, then Reply. The Transmit tab opens with the callsign filled in.
2. Go to another tab and back to Transmit. The callsign is still there.
3. Type one character in the directed field. Stations you messaged or heard appear in the dropdown.

Tested on a Fire HD 10.
