### PR TITLE
Fix: Prevent transmissions from starting mid-frame

### DIFF
--- a/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
+++ b/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
@@ -2247,8 +2247,25 @@ class JS8EngineService : Service() {
         heartbeatHandler.postDelayed(heartbeatRunnable, waitMs)
     }
 
-    private fun getFrameDurationMs(): Long {
-        return when (getPreferredTxSubmode()) {
+    /**
+     * Run [block] just before [submode]'s next frame boundary. The modulator
+     * assumes it was asked at a boundary, as the desktop's TX loop does;
+     * mid-period it joins the frame in progress and sends only its tail.
+     * The block must pass [TX_BOUNDARY_DELAY_S] as txDelaySec.
+     */
+    private fun scheduleAtNextTxBoundary(submode: Int, handler: Handler, block: () -> Unit) {
+        val period = framePeriodMs(submode)
+        val now = System.currentTimeMillis() + (engine?.timeDriftMs() ?: 0L)
+        val remaining = period - (((now % period) + period) % period)
+        if (remaining <= TX_BOUNDARY_LEAD_MS) {
+            block()
+        } else {
+            handler.postDelayed({ block() }, remaining - TX_BOUNDARY_LEAD_MS)
+        }
+    }
+
+    private fun framePeriodMs(submode: Int): Long {
+        return when (submode) {
             SUBMODE_SLOW -> 30000L
             SUBMODE_NORMAL -> 15000L
             SUBMODE_FAST -> 10000L
@@ -2256,6 +2273,8 @@ class JS8EngineService : Service() {
             else -> 15000L
         }
     }
+
+    private fun getFrameDurationMs(): Long = framePeriodMs(getPreferredTxSubmode())
 
     /**
      * True for messages that belong in the heartbeat sub-band: heartbeats
@@ -2328,25 +2347,32 @@ class JS8EngineService : Service() {
         val activeEngine = engine
         if (activeEngine != null) {
             val submode = getPreferredTxSubmode()
-            prepareEngineForTransmit(activeEngine)
-             val ok = activeEngine.transmitMessage(
-                text = payload,
-                myCall = callsign,
-                myGrid = grid,
-                selectedCall = "", // Broadcast-ish
-                submode = submode,
-                audioFrequencyHz = freq.toDouble(),
-                txDelaySec = 0.0,
-                forceIdentify = true, // Force ID to ensure callsign is sent
-                forceData = false
-            )
-            
-            if (ok) {
-                updateLastTxMessage(payload, "", submode, freq.toDouble())
-                broadcastTxState(TX_STATE_QUEUED)
-                startTxMonitor()
-            } else {
-                Log.e(TAG, "Failed to send heartbeat")
+            scheduleAtNextTxBoundary(submode, mainHandler) {
+                // Live query, not the monitor's cached flags: another
+                // deferred send may have started at this boundary.
+                if (engine !== activeEngine || activeEngine.isTransmitting()) {
+                    return@scheduleAtNextTxBoundary
+                }
+                prepareEngineForTransmit(activeEngine)
+                val ok = activeEngine.transmitMessage(
+                    text = payload,
+                    myCall = callsign,
+                    myGrid = grid,
+                    selectedCall = "", // Broadcast-ish
+                    submode = submode,
+                    audioFrequencyHz = freq.toDouble(),
+                    txDelaySec = TX_BOUNDARY_DELAY_S,
+                    forceIdentify = true, // Force ID to ensure callsign is sent
+                    forceData = false
+                )
+
+                if (ok) {
+                    updateLastTxMessage(payload, "", submode, freq.toDouble())
+                    broadcastTxState(TX_STATE_QUEUED)
+                    startTxMonitor()
+                } else {
+                    Log.e(TAG, "Failed to send heartbeat")
+                }
             }
         }
 
@@ -2419,28 +2445,31 @@ class JS8EngineService : Service() {
             "TX request: text='$payloadText', directed='${directed}', submode=$submode, freq=$audioFrequencyHz, delay=$txDelaySec, identify=$effectiveForceIdentify"
         )
 
-        prepareEngineForTransmit(activeEngine)
-        val ok = activeEngine.transmitMessage(
-            text = payloadText,
-            myCall = callsign,
-            myGrid = grid,
-            selectedCall = directed,
-            submode = submode,
-            audioFrequencyHz = audioFrequencyHz,
-            txDelaySec = txDelaySec,
-            forceIdentify = effectiveForceIdentify,
-            forceData = forceData
-        )
+        scheduleAtNextTxBoundary(submode, txHandler) {
+            if (engine !== activeEngine) return@scheduleAtNextTxBoundary
+            prepareEngineForTransmit(activeEngine)
+            val ok = activeEngine.transmitMessage(
+                text = payloadText,
+                myCall = callsign,
+                myGrid = grid,
+                selectedCall = directed,
+                submode = submode,
+                audioFrequencyHz = audioFrequencyHz,
+                txDelaySec = maxOf(txDelaySec, TX_BOUNDARY_DELAY_S),
+                forceIdentify = effectiveForceIdentify,
+                forceData = forceData
+            )
 
-        if (ok) {
-            Log.i(TAG, "TX request accepted")
-            updateLastTxMessage(payloadText, directed, submode, audioFrequencyHz)
-            broadcastTxState(TX_STATE_QUEUED)
-            startTxMonitor()
-        } else {
-            Log.e(TAG, "TX request rejected")
-            broadcastError("Failed to start transmit")
-            broadcastTxState(TX_STATE_FAILED)
+            if (ok) {
+                Log.i(TAG, "TX request accepted")
+                updateLastTxMessage(payloadText, directed, submode, audioFrequencyHz)
+                broadcastTxState(TX_STATE_QUEUED)
+                startTxMonitor()
+            } else {
+                Log.e(TAG, "TX request rejected")
+                broadcastError("Failed to start transmit")
+                broadcastTxState(TX_STATE_FAILED)
+            }
         }
     }
 
@@ -3572,25 +3601,30 @@ class JS8EngineService : Service() {
         val payload = text.trim()
         if (payload.isEmpty()) return false
 
-        prepareEngineForTransmit(activeEngine)
-        val ok = activeEngine.transmitMessage(
-            text = payload,
-            myCall = callsign,
-            myGrid = grid,
-            selectedCall = "",
-            submode = submode,
-            audioFrequencyHz = currentTxOffsetHz.toDouble(),
-            txDelaySec = 0.0,
-            forceIdentify = callsign.isNotBlank(),
-            forceData = false
-        )
+        scheduleAtNextTxBoundary(submode, mainHandler) {
+            if (engine !== activeEngine || activeEngine.isTransmitting()) {
+                return@scheduleAtNextTxBoundary
+            }
+            prepareEngineForTransmit(activeEngine)
+            val ok = activeEngine.transmitMessage(
+                text = payload,
+                myCall = callsign,
+                myGrid = grid,
+                selectedCall = "",
+                submode = submode,
+                audioFrequencyHz = currentTxOffsetHz.toDouble(),
+                txDelaySec = TX_BOUNDARY_DELAY_S,
+                forceIdentify = callsign.isNotBlank(),
+                forceData = false
+            )
 
-        if (ok) {
-            updateLastTxMessage(payload, "", submode, currentTxOffsetHz.toDouble())
-            broadcastTxState(TX_STATE_QUEUED)
-            startTxMonitor()
+            if (ok) {
+                updateLastTxMessage(payload, "", submode, currentTxOffsetHz.toDouble())
+                broadcastTxState(TX_STATE_QUEUED)
+                startTxMonitor()
+            }
         }
-        return ok
+        return true
     }
 
     private fun sendAutoReply(
@@ -3613,28 +3647,33 @@ class JS8EngineService : Service() {
         val directedCall = directed?.trim().orEmpty().uppercase()
         if (requireDirected && directedCall.isBlank()) return
 
-        prepareEngineForTransmit(activeEngine)
-        val ok = activeEngine.transmitMessage(
-            text = payloadText,
-            myCall = callsign,
-            myGrid = grid,
-            selectedCall = directedCall,
-            submode = submode,
-            audioFrequencyHz = currentTxOffsetHz.toDouble(),
-            txDelaySec = 0.0,
-            forceIdentify = callsign.isNotBlank(),
-            forceData = forceData
-        )
+        scheduleAtNextTxBoundary(submode, mainHandler) {
+            if (engine !== activeEngine || activeEngine.isTransmitting()) {
+                return@scheduleAtNextTxBoundary
+            }
+            prepareEngineForTransmit(activeEngine)
+            val ok = activeEngine.transmitMessage(
+                text = payloadText,
+                myCall = callsign,
+                myGrid = grid,
+                selectedCall = directedCall,
+                submode = submode,
+                audioFrequencyHz = currentTxOffsetHz.toDouble(),
+                txDelaySec = TX_BOUNDARY_DELAY_S,
+                forceIdentify = callsign.isNotBlank(),
+                forceData = forceData
+            )
 
-        if (ok) {
-            Log.i(TAG, "Autoreply queued: to=$directedCall text='$payloadText'")
-            updateLastTxMessage(payloadText, directedCall, submode, currentTxOffsetHz.toDouble())
-            broadcastTxState(TX_STATE_QUEUED)
-            startTxMonitor()
-        } else {
-            Log.e(TAG, "Autoreply rejected")
-            broadcastError("Failed to start transmit")
-            broadcastTxState(TX_STATE_FAILED)
+            if (ok) {
+                Log.i(TAG, "Autoreply queued: to=$directedCall text='$payloadText'")
+                updateLastTxMessage(payloadText, directedCall, submode, currentTxOffsetHz.toDouble())
+                broadcastTxState(TX_STATE_QUEUED)
+                startTxMonitor()
+            } else {
+                Log.e(TAG, "Autoreply rejected")
+                broadcastError("Failed to start transmit")
+                broadcastTxState(TX_STATE_FAILED)
+            }
         }
     }
 
@@ -3819,6 +3858,10 @@ class JS8EngineService : Service() {
         private const val HEARD_WINDOW_MS = 15 * 60 * 1000L
         private val HEARD_EXCLUDE_TOKENS = setOf("CQ", "HB", "HEARTBEAT", "ALLCALL", "@ALLCALL")
         private const val RELAY_BUFFER_TIMEOUT_MS = 90_000L
+        // Fire this far before the boundary; the delay must exceed the lead
+        // or the modulator joins the frame already in progress.
+        private const val TX_BOUNDARY_LEAD_MS = 1500L
+        private const val TX_BOUNDARY_DELAY_S = 2.0
         private const val RELAY_FREQUENCY_TOLERANCE_HZ = 10.0f
         private const val RELAY_EOM_MARKER = "\u2662"
         private const val SUBMODE_NORMAL = 0


### PR DESCRIPTION
## What

1. Defers every engine transmit call to just before the next frame boundary, on the engine's drifted clock.
2. Passes a `txDelaySec` that lands the start in the next period, so the modulator doesn't join the frame already in progress.
3. Re-checks the engine instance and whether it's already transmitting inside each deferred send, since two of them can now arrive at the same boundary.

## Why

Sending a heartbeat or other message partway through a period keyed the radio right away and transmitted for whatever was left of the frame, often a second or two. The modulator assumes it's being asked at a period boundary, which holds on the desktop because the TX loop only ever asks there, but nothing on the Android side was providing that timing.

## Test

1. Start monitoring and wait a few seconds into a frame, then send a heartbeat.
2. PTT should key just before the next 15s boundary instead of immediately, and the transmission should run full length.