### PR TITLE
Fix app freeze on engine stop when rig disconnected

### DIFF
--- a/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
+++ b/android/app/src/main/java/com/js8call/example/service/JS8EngineService.kt
@@ -40,7 +40,6 @@ import com.js8call.example.util.TxMessageClassifier
 import java.util.Calendar
 import java.util.Locale
 import java.util.TimeZone
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.TimeUnit
 
@@ -249,59 +248,7 @@ class JS8EngineService : Service() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
-        usbSerialBridge = UsbSerialBridge(applicationContext)
-        bluetoothSerialBridge = BluetoothSerialBridge(applicationContext)
-        trusdxDirectSerial = TruSdxDirectSerial(applicationContext)
-        qmxDirectSerial = QmxDirectSerial(applicationContext)
-        hamlibRigControl = HamlibRigControl()
-        trusdxSerialSession = trusdxDirectSerial?.let { direct ->
-            TruSdxSerialSession(
-                direct,
-                object : TruSdxSerialSession.Listener {
-                    override fun onCatMessage(message: String) {
-                        if (isTruSdxDiagnosticsEnabled()) {
-                            Log.v(TAG, "TruSDX CAT <= $message")
-                        }
-                    }
-
-                    override fun onAudioFrame(samplesU8: ByteArray) {
-                        handleTruSdxAudioFrame(samplesU8)
-                    }
-
-                    override fun onParserResync(reason: String) {
-                        trusdxParserResyncs += 1
-                        if (isTruSdxDiagnosticsEnabled()) {
-                            Log.w(TAG, "TruSDX parser resync ($reason), count=$trusdxParserResyncs")
-                        }
-                    }
-
-                    override fun onIoError(message: String) {
-                        Log.w(TAG, "TruSDX I/O error: $message")
-                        trusdxConnected = false
-                        broadcastError("TruSDX serial link lost")
-                    }
-
-                }
-            )
-        }
-        qmxCatSession = qmxDirectSerial?.let { direct ->
-            QmxCatSession(direct, object : QmxCatSession.Listener {
-                override fun onFrequency(frequencyHz: Long) {
-                    currentDialHz = frequencyHz
-                    mainHandler.post { broadcastRadioFrequency(frequencyHz) }
-                }
-
-                override fun onMessage(message: String) {
-                    Log.d(TAG, "QMX CAT <= $message")
-                }
-
-                override fun onIoError(message: String) {
-                    Log.w(TAG, "QMX CAT I/O error: $message")
-                    qmxConnected = false
-                    mainHandler.post { broadcastError("QMX CAT link lost") }
-                }
-            })
-        }
+        createRigTransports()
         txHandlerThread.start()
         txHandler = Handler(txHandlerThread.looper)
         txMonitorHandler = Handler(Looper.getMainLooper())
@@ -447,6 +394,66 @@ class JS8EngineService : Service() {
 
             val notificationManager = getSystemService(NotificationManager::class.java)
             notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    /**
+     * Build the rig transports. Called again on stop, once the old ones have
+     * been handed to the teardown, so a restart never reaches a closing link.
+     */
+    private fun createRigTransports() {
+        usbSerialBridge = UsbSerialBridge(applicationContext)
+        bluetoothSerialBridge = BluetoothSerialBridge(applicationContext)
+        trusdxDirectSerial = TruSdxDirectSerial(applicationContext)
+        qmxDirectSerial = QmxDirectSerial(applicationContext)
+        hamlibRigControl = HamlibRigControl()
+        trusdxSerialSession = trusdxDirectSerial?.let { direct ->
+            TruSdxSerialSession(
+                direct,
+                object : TruSdxSerialSession.Listener {
+                    override fun onCatMessage(message: String) {
+                        if (isTruSdxDiagnosticsEnabled()) {
+                            Log.v(TAG, "TruSDX CAT <= $message")
+                        }
+                    }
+
+                    override fun onAudioFrame(samplesU8: ByteArray) {
+                        handleTruSdxAudioFrame(samplesU8)
+                    }
+
+                    override fun onParserResync(reason: String) {
+                        trusdxParserResyncs += 1
+                        if (isTruSdxDiagnosticsEnabled()) {
+                            Log.w(TAG, "TruSDX parser resync ($reason), count=$trusdxParserResyncs")
+                        }
+                    }
+
+                    override fun onIoError(message: String) {
+                        Log.w(TAG, "TruSDX I/O error: $message")
+                        trusdxConnected = false
+                        broadcastError("TruSDX serial link lost")
+                    }
+
+                }
+            )
+        }
+        qmxCatSession = qmxDirectSerial?.let { direct ->
+            QmxCatSession(direct, object : QmxCatSession.Listener {
+                override fun onFrequency(frequencyHz: Long) {
+                    currentDialHz = frequencyHz
+                    mainHandler.post { broadcastRadioFrequency(frequencyHz) }
+                }
+
+                override fun onMessage(message: String) {
+                    Log.d(TAG, "QMX CAT <= $message")
+                }
+
+                override fun onIoError(message: String) {
+                    Log.w(TAG, "QMX CAT I/O error: $message")
+                    qmxConnected = false
+                    mainHandler.post { broadcastError("QMX CAT link lost") }
+                }
+            })
         }
     }
 
@@ -1500,14 +1507,26 @@ class JS8EngineService : Service() {
                 rigPttCommandPending = false
                 rigPttCompletion = null
             }
-            if (isRigControlConnected()) {
-                if (!releaseRigPttForShutdown()) {
-                    Log.e(TAG, "Unable to confirm PTT release during shutdown")
-                }
-            }
+            // Rig teardown belongs on the TX handler, not here. With the radio
+            // gone a CAT command blocks for hamlib's full timeout, and every
+            // HamlibRigControl method shares one monitor, so close() waits
+            // behind it. That was nine seconds on the main thread.
+            val shutdownMode = rigControlMode
+            val shutdownTransport = rtsPttTransport
+            val shutdownHamlib = hamlibRigControl
+            val shutdownUsb = usbSerialBridge
+            val shutdownBluetooth = bluetoothSerialBridge
+            val shutdownTruSdx = trusdxSerialSession
+            val shutdownQmx = qmxCatSession
+            val shutdownNetwork = rigCtlClient
+            val shouldReleasePtt = isRigControlConnected()
 
-            // Disconnect rig control on background thread
-            val networkClientToDisconnect = rigCtlClient
+            // Unregistering clears one native global whichever bridge asks, so
+            // it stays here: deferred, it could wipe a restart's registration.
+            shutdownUsb?.unregisterNative()
+            shutdownBluetooth?.unregisterNative()
+
+            createRigTransports()
             rigCtlClient = null
             rigCtlConnected = false
             rigCtlErrorShown = false
@@ -1523,9 +1542,6 @@ class JS8EngineService : Service() {
             trusdxRxKeepaliveCount = 0L
             rtsPttTransport = null
             rigControlMode = "none"
-            hamlibRigControl?.close()
-            trusdxSerialSession?.stop()
-            qmxCatSession?.stop()
             if (isTruSdxDiagnosticsEnabled() &&
                 (trusdxRxFrames > 0 || trusdxTxFrames > 0 || trusdxParserResyncs > 0 || trusdxTxDrops > 0 || trusdxRxUnderruns > 0 || trusdxRxFrameDrops > 0)
             ) {
@@ -1534,15 +1550,36 @@ class JS8EngineService : Service() {
                     "TruSDX diagnostics: rxFrames=$trusdxRxFrames rxSamples=$trusdxRxSamples rxFrameDrops=$trusdxRxFrameDrops rxSubmitDrops=$trusdxRxSubmitDrops rxUnderruns=$trusdxRxUnderruns txFrames=$trusdxTxFrames txSamples=$trusdxTxSamples txSilent=$trusdxTxSilentFrames txDrops=$trusdxTxDrops parserResyncs=$trusdxParserResyncs"
                 )
             }
-            usbSerialBridge?.unregisterNative()
-            usbSerialBridge?.close()
-            bluetoothSerialBridge?.close()
-            bluetoothSerialBridge?.unregisterNative()
 
-            if (networkClientToDisconnect != null) {
-                Thread {
-                    networkClientToDisconnect.disconnect()
-                }.start()
+            txHandler.post {
+                if (shouldReleasePtt) {
+                    // Captured references, not setRigPtt: the fields already
+                    // hold the transports the next start will use.
+                    val released = when (shutdownMode) {
+                        "network" -> shutdownNetwork?.setPtt(false) == true
+                        "hamlib_usb" -> shutdownHamlib?.setPtt(false) == true
+                        "rts_ptt" -> when (shutdownTransport) {
+                            SerialTransport.USB -> shutdownUsb?.setRts(false) == true
+                            SerialTransport.BLUETOOTH -> shutdownBluetooth?.setRts(false) == true
+                            else -> false
+                        }
+                        "trusdx_serial" -> shutdownTruSdx?.setPtt(false) == true
+                        "qmx_serial" -> shutdownQmx?.setPtt(false) == true
+                        else -> false
+                    }
+                    if (released) {
+                        synchronized(pttStateLock) { rigPttAsserted = false }
+                    } else {
+                        Log.e(TAG, "Unable to confirm PTT release during shutdown")
+                    }
+                }
+                shutdownHamlib?.close()
+                shutdownTruSdx?.stop()
+                shutdownQmx?.stop()
+                shutdownUsb?.close()
+                shutdownBluetooth?.close()
+                shutdownNetwork?.disconnect()
+                Log.i(TAG, "Rig control torn down")
             }
 
             pskReporterClient?.stop(flush = true)
@@ -2846,35 +2883,6 @@ class JS8EngineService : Service() {
         engine?.setTransmitReady(false)
         broadcastError(message)
         broadcastTxState(TX_STATE_FAILED)
-    }
-
-    private fun releaseRigPttForShutdown(): Boolean {
-        if (Looper.myLooper() == txHandler.looper) {
-            val released = setRigPtt(false)
-            if (released) rigPttAsserted = false
-            return released
-        }
-
-        val completed = CountDownLatch(1)
-        var released = false
-        txHandler.post {
-            try {
-                released = setRigPtt(false)
-                if (released) {
-                    synchronized(pttStateLock) {
-                        rigPttAsserted = false
-                    }
-                }
-            } finally {
-                completed.countDown()
-            }
-        }
-        completed.await()
-        if (!released) {
-            released = setRigPtt(false)
-            if (released) rigPttAsserted = false
-        }
-        return released
     }
 
     /**


### PR DESCRIPTION
## What

1. Moves rig teardown onto the TX handler
2. Removes `releaseRigPttForShutdown` and the unbounded `CountDownLatch.await()` the main thread sat in, along with the ad-hoc `Thread {}` that disconnected the network client.
3. Moves the transport construction out of `onCreate` into `createRigTransports()`

## Why

Stopping the engine with the rig gone froze the app. The release waited on a latch with no timeout, and `close()` then ran in line behind it. Every `HamlibRigControl` method shares one monitor, so a wedged CAT command held both for hamlib's own timeout, and the USB bridge has the same shape where close takes a write lock a stuck read still holds. On my tablet with the radio pulled mid-transmission that was nine seconds of dead main thread, which is long enough for Android to call the app unresponsive.

## Test

Need a rigctld to accepts the connection and never answer

For simulation without a real rig...

1. On your machine: `python3 -c "import socket;s=socket.socket();s.setsockopt(1,2,1);s.bind(('0.0.0.0',4532));s.listen(1);c,_=s.accept();input()"`
2. Settings, rig control on, type Network, host your machine's IP, port 4532.
3. Start, wait for `Connected to rigctld` in logcat, then Stop.
4. The UI should go back to Off right away, and `Rig control torn down` should turn up in logcat about five seconds later on the TX handler thread rather than the main one.
5. Start again. Rig control should reconnect.

On the emulator, before and after:

```
master
18:43:59.103  5745 5745  Stopping engine
18:44:04.158  5745 5745  RigCtlClient: NetworkOnMainThreadException
18:44:04.164  5745 5745  Engine stopped                          <- main thread, +5.06s

this branch
18:45:08.474  5880 5880  Stopping engine
18:45:08.537  5880 5880  Engine stopped                          <- main thread, +0.06s
18:45:13.542  5880 5913  Unable to confirm PTT release during shutdown
18:45:13.542  5880 5913  Rig control torn down                   <- TX handler, +5.07s
```
